### PR TITLE
fix: give binding support to objects and arrays

### DIFF
--- a/.changeset/many-pens-promise.md
+++ b/.changeset/many-pens-promise.md
@@ -1,0 +1,5 @@
+---
+'svelte-fast-dimension': patch
+---
+
+Support binding on objects and arrays

--- a/packages/svelte-fast-dimension/src/index.ts
+++ b/packages/svelte-fast-dimension/src/index.ts
@@ -6,6 +6,16 @@ import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 const bindingNames = ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight'];
 const bindings = bindingNames.map((n) => 'bind:' + n);
 
+const expressionToString = (expression: any): string => {
+	if (expression.type == 'MemberExpression') {
+		const propName =
+			expression.property.type === 'Literal' ? expression.property.raw : expression.property.name;
+		const suffix = expression.computed ? `[${propName}]` : `.${propName}`;
+
+		return `${expressionToString(expression.object)}${suffix}`;
+	}
+	return expression.type === 'Literal' ? expression.raw : expression.name;
+};
 export function fastDimension(): PreprocessorGroup {
 	return {
 		// @ts-expect-error
@@ -25,7 +35,7 @@ export function fastDimension(): PreprocessorGroup {
 
 						const expressions = elementToCompiledExpressions.get(parent) as string[];
 
-						expressions.push(`${node.expression.name} = e.target.${node.name}`);
+						expressions.push(`${expressionToString(node.expression)} = e.target.${node.name}`);
 						s.overwrite(node.start, node.end, '');
 					}
 				}

--- a/packages/svelte-fast-dimension/src/index.ts
+++ b/packages/svelte-fast-dimension/src/index.ts
@@ -6,16 +6,6 @@ import type { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 const bindingNames = ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight'];
 const bindings = bindingNames.map((n) => 'bind:' + n);
 
-const expressionToString = (expression: any): string => {
-	if (expression.type == 'MemberExpression') {
-		const propName =
-			expression.property.type === 'Literal' ? expression.property.raw : expression.property.name;
-		const suffix = expression.computed ? `[${propName}]` : `.${propName}`;
-
-		return `${expressionToString(expression.object)}${suffix}`;
-	}
-	return expression.type === 'Literal' ? expression.raw : expression.name;
-};
 export function fastDimension(): PreprocessorGroup {
 	return {
 		// @ts-expect-error
@@ -34,8 +24,8 @@ export function fastDimension(): PreprocessorGroup {
 							elementToCompiledExpressions.set(parent, []);
 
 						const expressions = elementToCompiledExpressions.get(parent) as string[];
-
-						expressions.push(`${expressionToString(node.expression)} = e.target.${node.name}`);
+						const boundVar = s.slice(node.expression.start, node.expression.end);
+						expressions.push(`${boundVar} = e.target.${node.name}`);
 						s.overwrite(node.start, node.end, '');
 					}
 				}

--- a/packages/svelte-fast-dimension/tests/Input.svelte
+++ b/packages/svelte-fast-dimension/tests/Input.svelte
@@ -1,5 +1,8 @@
 <script>
 	let clientWidth, foo, w, h, w2, h2;
+	let index = 0;
+	let myObject = { b: 0, c: { d: [] } };
+	let myArray = [{ width: 0 }, { height: 1 }];
 </script>
 
 <div bind:clientWidth />
@@ -7,3 +10,6 @@
 <div bind:clientWidth bind:clientHeight={w} />
 <div bind:clientWidth={w} bind:clientHeight={h} bind:offsetWidth={w2} bind:offsetHeight={h2} />
 <div data-foo="bar" bind:clientWidth={foo} />
+<div bind:clientWidth={myObject.width} />
+<div bind:clientWidth={myArray[0].b} bind:clientHeight={myArray[1].height} />
+<div bind:clientWidth={myArray[index]} />

--- a/packages/svelte-fast-dimension/tests/Output.svelte
+++ b/packages/svelte-fast-dimension/tests/Output.svelte
@@ -1,5 +1,8 @@
 <script>import { resize as ___resize } from "svelte-fast-dimension/action";
 	let clientWidth, foo, w, h, w2, h2;
+	let index = 0;
+	let myObject = { b: 0, c: { d: [] } };
+	let myArray = [{ width: 0 }, { height: 1 }];
 </script>
 
 <div use:___resize on:fd:resize={(e) => { clientWidth = e.target.clientWidth }}  />
@@ -7,3 +10,6 @@
 <div use:___resize on:fd:resize={(e) => { clientWidth = e.target.clientWidth; w = e.target.clientHeight }}   />
 <div use:___resize on:fd:resize={(e) => { w = e.target.clientWidth; h = e.target.clientHeight; w2 = e.target.offsetWidth; h2 = e.target.offsetHeight }}     />
 <div use:___resize on:fd:resize={(e) => { foo = e.target.clientWidth }} data-foo="bar"  />
+<div use:___resize on:fd:resize={(e) => { myObject.width = e.target.clientWidth }}  />
+<div use:___resize on:fd:resize={(e) => { myArray[0].b = e.target.clientWidth; myArray[1].height = e.target.clientHeight }}   />
+<div use:___resize on:fd:resize={(e) => { myArray[index] = e.target.clientWidth }}  />


### PR DESCRIPTION
With this PR we are giving support to `MemberExpression` and `Literal`, which allow us to bind objects and arrays, this allow us to run the binding within a `each` expression or receive more complex objects:

```js
let myObject={height:0}
let myArray = [{ width: 0 }, { height: 1 }];
<div bind:clientHeight={myObject.height} />
<div bind:clientWidth={myArray[0].b} bind:clientHeight={myArray[1].height} />
```